### PR TITLE
Don't fail immediatly if legacy_origin/origins not set.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@ class unattended_upgrades (
   $notify_update        = undef,
 ) inherits ::unattended_upgrades::params {
 
+  if $legacy_origin == undef or $origins == undef {
+    fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins.')
+  }
+
   validate_bool(
     $install_on_shutdown,
     $legacy_origin,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,8 @@ class unattended_upgrades::params {
       }
     }
     default: {
-      fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins')
+      $legacy_origin = undef
+      $origins       = undef
     }
   }
 }


### PR DESCRIPTION
Check that legacy_origins/origins are set only where we need to prevent early failure of the process -- even before we can provide a value for these parameters.