### PR TITLE
Default `notify_update` to false

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   gem 'rspec',                                                      :require => false
   gem 'puppet-blacksmith',                                          :require => false, :git => 'https://github.com/voxpupuli/puppet-blacksmith.git'
   gem 'voxpupuli-release',                                          :require => false, :git => 'https://github.com/voxpupuli/voxpupuli-release-gem.git'
-  gem 'rubocop',                                                    :require => false
+  gem 'rubocop', '0.35.0',                                          :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppetlabs_spec_helper',                                     :require => false
   gem 'puppet-lint-absolute_classname-check',                       :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class unattended_upgrades (
   $upgrade              = 1,
   $upgradeable_packages = {},
   $verbose              = 0,
-  $notify_update        = undef,
+  $notify_update        = false,
 ) inherits ::unattended_upgrades::params {
 
   if $legacy_origin == undef or $origins == undef {

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -19,12 +19,14 @@ describe 'unattended_upgrades' do
     it {
       should contain_apt__conf('unattended-upgrades').with(
         :require => 'Package[unattended-upgrades]',
+        :notify_update => false,
       )
     }
 
     it {
       should contain_apt__conf('periodic').with(
         :require => 'Package[unattended-upgrades]',
+        :notify_update => false,
       )
     }
 
@@ -289,17 +291,20 @@ describe 'unattended_upgrades' do
         },
         :dl_limit             => 70,
         :random_sleep         => 300,
+        :notify_update        => true,
       }
     end
     it { should contain_package('unattended-upgrades') }
 
     it { should contain_apt__conf('unattended-upgrades').with(
       :require => 'Package[unattended-upgrades]',
+      :notify_update => true,
     )
     }
 
     it { should contain_apt__conf('periodic').with(
       :require => 'Package[unattended-upgrades]',
+      :notify_update => true,
     )
     }
 

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -18,21 +18,21 @@ describe 'unattended_upgrades' do
 
     it {
       should contain_apt__conf('unattended-upgrades').with(
-        'require' => 'Package[unattended-upgrades]',
+        :require => 'Package[unattended-upgrades]',
       )
     }
 
     it {
       should contain_apt__conf('periodic').with(
-        'require' => 'Package[unattended-upgrades]',
+        :require => 'Package[unattended-upgrades]',
       )
     }
 
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         /Unattended-Upgrade::Origins-Pattern {/
       ).with_content(
@@ -58,9 +58,9 @@ describe 'unattended_upgrades' do
 
     it {
       should create_file(file_periodic).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         /APT::Periodic::Enable "1";/
       ).with_content(
@@ -89,7 +89,7 @@ describe 'unattended_upgrades' do
     }
 
     it { should contain_apt__conf('auto-upgrades').with(
-      'ensure' => 'absent',
+      :ensure => 'absent',
     )
     }
   end
@@ -103,9 +103,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This section varies for different releases
         /\Unattended-Upgrade::Allowed-Origins\ {\n
@@ -126,9 +126,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This section varies for different releases
         /\Unattended-Upgrade::Origins-Pattern\ {\n
@@ -148,9 +148,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This section varies for different releases
         /\Unattended-Upgrade::Origins-Pattern\ {\n
@@ -169,9 +169,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
@@ -190,9 +190,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
@@ -211,9 +211,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
@@ -232,9 +232,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
@@ -253,9 +253,9 @@ describe 'unattended_upgrades' do
     } }
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       )
     }
   end
@@ -294,20 +294,20 @@ describe 'unattended_upgrades' do
     it { should contain_package('unattended-upgrades') }
 
     it { should contain_apt__conf('unattended-upgrades').with(
-      'require' => 'Package[unattended-upgrades]',
+      :require => 'Package[unattended-upgrades]',
     )
     }
 
     it { should contain_apt__conf('periodic').with(
-      'require' => 'Package[unattended-upgrades]',
+      :require => 'Package[unattended-upgrades]',
     )
     }
 
     it {
       should create_file(file_unattended).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         /Unattended-Upgrade::Allowed-Origins {\n\t"bananas";\n};/
       ).with_content(
@@ -333,9 +333,9 @@ describe 'unattended_upgrades' do
 
     it {
       should create_file(file_periodic).with(
-        'owner'   => 'root',
-        'group'   => 'root',
-        'mode'    => '0644',
+        :owner   => 'root',
+        :group   => 'root',
+        :mode    => '0644',
       ).with_content(
         /APT::Periodic::Enable "1";/
       ).with_content(
@@ -367,7 +367,7 @@ describe 'unattended_upgrades' do
 
     it {
       should contain_apt__conf('auto-upgrades').with(
-        'ensure' => 'absent',
+        :ensure => 'absent',
       )
     }
   end


### PR DESCRIPTION
The settings that we write for unattended-upgrades, though part of `/etc/apt` on the filesystem, do not affect apt's behaviour. As such notifying `apt::update` only serves to slow us down.