### PR TITLE
LinuxMint: Add support for Linux Mint

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Using unattended\_upgrades simply consists of including the module and if needed
 
 ## Limitations
 
-This module should work across all versions of Debian/Ubuntu.
+This module should work across all versions of Debian, Ubuntu, and Linux Mint.
 
 ## License
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class unattended_upgrades::params {
     $xfacts = {
       'lsbdistid'           => $::lsbdistid,
       'lsbdistcodename'     => $::lsbdistcodename,
+      'lsbmajdistrelease'   => $::lsbmajdistrelease,
     }
   } else {
     # Strict variables facts lookup compatibility
@@ -30,6 +31,10 @@ class unattended_upgrades::params {
       },
       'lsbdistcodename' => defined('$lsbdistcodename') ? {
         true    => $::lsbdistcodename,
+        default => undef,
+      },
+      'lsbmajdistrelease' => defined('$lsbmajdistrelease') ? {
+        true    => $::lsbmajdistrelease,
         default => undef,
       },
     }
@@ -80,6 +85,37 @@ class unattended_upgrades::params {
           $origins            = [
             '${distro_id}:${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
             #'${distro_id}:${distro_codename}-updates', #lint:ignore:single_quote_string_with_variables
+          ]
+        }
+      }
+    }
+    'LinuxMint': {
+      case $xfacts['lsbmajdistrelease'] {
+        # Linux Mint 13 is based on Ubuntu 12.04
+        '13': {
+          $legacy_origin      = true
+          $origins            = [
+            'Ubuntu:precise-security',
+          ]
+        }
+        # Linux Mint 17* is based on Ubuntu 14.04.
+        '17': {
+          $legacy_origin      = true
+          $origins            = [
+            'Ubuntu:trusty-security',
+          ]
+        }
+        # Linux Mint 18* is based on Ubuntu 16.04
+        '18': {
+          $legacy_origin      = true
+          $origins            = [
+            'Ubuntu:xenial-security',
+          ]
+        }
+        default: {
+          $legacy_origin      = true
+          $origins            = [
+            '${distro_id}:${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
           ]
         }
       }

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -293,6 +293,72 @@ describe 'unattended_upgrades' do
     }
   end
 
+  context 'with defaults on Linux Mint 13 Maya' do
+    let(:facts) { {
+      osfamily: 'Debian',
+      lsbdistid: 'LinuxMint',
+      lsbdistcodename: 'maya',
+      lsbdistrelease: '13',
+      lsbmajdistrelease: '13',
+    } }
+    it {
+      should create_file(file_unattended).with(
+        'owner' => 'root',
+        'group' => 'root',
+        'mode'  => '0644',
+      ).with_content(
+        # This is the only section that's different for Ubuntu compared to Debian
+        /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"Ubuntu\:precise-security";\n
+        };/x
+      )
+    }
+  end
+
+  context 'with defaults on Linux Mint 17.3 Rosa' do
+    let(:facts) { {
+      osfamily: 'Debian',
+      lsbdistid: 'LinuxMint',
+      lsbdistcodename: 'rosa',
+      lsbdistrelease: '17.3',
+      lsbmajdistrelease: '17',
+    } }
+    it {
+      should create_file(file_unattended).with(
+        'owner' => 'root',
+        'group' => 'root',
+        'mode'  => '0644',
+      ).with_content(
+        # This is the only section that's different for Ubuntu compared to Debian
+        /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"Ubuntu\:trusty-security";\n
+        };/x
+      )
+    }
+  end
+
+  context 'with defaults on Linux Mint 18 Sarah' do
+    let(:facts) { {
+      osfamily: 'Debian',
+      lsbdistid: 'LinuxMint',
+      lsbdistcodename: 'sarah',
+      lsbdistrelease: '18',
+      lsbmajdistrelease: '18',
+    } }
+    it {
+      should create_file(file_unattended).with(
+        'owner' => 'root',
+        'group' => 'root',
+        'mode'  => '0644',
+      ).with_content(
+        # This is the only section that's different for Ubuntu compared to Debian
+        /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"Ubuntu\:xenial-security";\n
+        };/x
+      )
+    }
+  end
+
   context 'set all the things' do
     let :params do
       {


### PR DESCRIPTION
Tested using LinuxMint 18 Sarah and Puppet 3.8.5.