### PR TITLE
Make parameter validation more strict

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,12 +23,21 @@ class unattended_upgrades (
 
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
+  validate_integer($_age['min'], undef, 0)
+  validate_integer($_age['max'], undef, 0)
 
   validate_hash($auto)
   $_auto = merge($::unattended_upgrades::default_auto, $auto)
+  validate_integer($_auto['clean'], undef, 0)
+  validate_bool($_auto['fix_interrupted_dpkg'])
+  validate_bool($_auto['reboot'])
+  validate_string($_auto['reboot_time'])
+  validate_bool($_auto['remove'])
 
   validate_hash($backup)
   $_backup = merge($::unattended_upgrades::default_backup, $backup)
+  validate_integer($_backup['archive_interval'], undef, 0)
+  validate_integer($_backup['level'], undef, 0)
 
   validate_array($blacklist)
 
@@ -47,10 +56,8 @@ class unattended_upgrades (
   }
 
   validate_hash($mail)
-  if $mail['only_on_error'] {
-    validate_bool($mail['only_on_error'])
-  }
   $_mail = merge($::unattended_upgrades::default_mail, $mail)
+  validate_bool($_mail['only_on_error'])
 
   validate_bool($minimal_steps)
 
@@ -60,7 +67,7 @@ class unattended_upgrades (
     validate_integer($random_sleep, undef, 0)
   }
 
-  validate_integer($size)
+  validate_integer($size, undef, 0)
 
   validate_integer($update, undef, 0)
 
@@ -68,6 +75,8 @@ class unattended_upgrades (
 
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)
+  validate_integer($_upgradeable_packages['download_only'], undef, 0)
+  validate_integer($_upgradeable_packages['debdelta'], undef, 0)
 
   validate_integer($verbose, undef, 0)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,16 +50,14 @@ class unattended_upgrades (
   validate_bool($install_on_shutdown)
 
   validate_bool($legacy_origin)
-  validate_array($origins)
-  if $legacy_origin == undef or $origins == undef {
-    fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins.')
-  }
 
   validate_hash($mail)
   $_mail = merge($::unattended_upgrades::default_mail, $mail)
   validate_bool($_mail['only_on_error'])
 
   validate_bool($minimal_steps)
+
+  validate_array($origins)
 
   validate_string($package_ensure)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,18 @@ class unattended_upgrades (
   validate_bool($_options['force_confold'])
   validate_bool($_options['force_confnew'])
   validate_bool($_options['force_confmiss'])
+  if $dl_limit != undef {
+    validate_integer($dl_limit, undef, 0)
+  }
+  validate_integer($enable, 1, 0)
+  validate_string($package_ensure)
+  if $random_sleep != undef {
+    validate_integer($random_sleep, undef, 0)
+  }
+  validate_integer($update, undef, 0)
+  validate_integer($upgrade, undef, 0)
+  validate_integer($verbose, undef, 0)
+  validate_bool($notify_update)
 
   package { 'unattended-upgrades':
     ensure => $package_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,49 +21,64 @@ class unattended_upgrades (
   $options              = {},
 ) inherits ::unattended_upgrades::params {
 
+  validate_hash($age)
+  $_age = merge($::unattended_upgrades::default_age, $age)
+
+  validate_hash($auto)
+  $_auto = merge($::unattended_upgrades::default_auto, $auto)
+
+  validate_hash($backup)
+  $_backup = merge($::unattended_upgrades::default_backup, $backup)
+
+  validate_array($blacklist)
+
+  if $dl_limit != undef {
+    validate_integer($dl_limit, undef, 0)
+  }
+
+  validate_integer($enable, 1, 0)
+
+  validate_bool($install_on_shutdown)
+
+  validate_bool($legacy_origin)
+  validate_array($origins)
   if $legacy_origin == undef or $origins == undef {
     fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins.')
   }
 
-  validate_bool(
-    $install_on_shutdown,
-    $legacy_origin,
-    $minimal_steps,
-  )
-  validate_array($blacklist)
-  validate_array($origins)
-  validate_hash($auto)
-  $_auto = merge($::unattended_upgrades::default_auto, $auto)
   validate_hash($mail)
   if $mail['only_on_error'] {
     validate_bool($mail['only_on_error'])
   }
   $_mail = merge($::unattended_upgrades::default_mail, $mail)
-  validate_hash($backup)
-  $_backup = merge($::unattended_upgrades::default_backup, $backup)
-  validate_hash($age)
-  $_age = merge($::unattended_upgrades::default_age, $age)
+
+  validate_bool($minimal_steps)
+
+  validate_string($package_ensure)
+
+  if $random_sleep != undef {
+    validate_integer($random_sleep, undef, 0)
+  }
+
   validate_integer($size)
+
+  validate_integer($update, undef, 0)
+
+  validate_integer($upgrade, undef, 0)
+
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)
+
+  validate_integer($verbose, undef, 0)
+
+  validate_bool($notify_update)
+
   validate_hash($options)
   $_options = merge($unattended_upgrades::default_options, $options)
   validate_bool($_options['force_confdef'])
   validate_bool($_options['force_confold'])
   validate_bool($_options['force_confnew'])
   validate_bool($_options['force_confmiss'])
-  if $dl_limit != undef {
-    validate_integer($dl_limit, undef, 0)
-  }
-  validate_integer($enable, 1, 0)
-  validate_string($package_ensure)
-  if $random_sleep != undef {
-    validate_integer($random_sleep, undef, 0)
-  }
-  validate_integer($update, undef, 0)
-  validate_integer($upgrade, undef, 0)
-  validate_integer($verbose, undef, 0)
-  validate_bool($notify_update)
 
   package { 'unattended-upgrades':
     ensure => $package_ensure,


### PR DESCRIPTION
I broke APT on my server by mixing up which parameters take integers and which take booleans. This pull request aims to prevent such situations in the future by validating that every parameter has a sensible value.

All parameters to `class unattended_upgrades` are now validated, including contents of hashes. To make this fact easier to check at a glance, I've also reordered the validation code to match the order of parameters to the class.