### PR TITLE
Remove 'pe' requirement from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -26,12 +26,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 4.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0 < 4.0.0"
+      "version_requirement": ">= 3.4.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
The forge no longer uses it.  See
https://groups.google.com/forum/#!msg/puppet-users/nkRPvG4q0Oo/GmXa109aJQAJ

The module is puppet 4 compatible, so adjust `puppet`
`version_requirement` too.

Fixes #63