### PR TITLE
Fix order of options to prevent swapping of lines

### DIFF
--- a/templates/options.erb
+++ b/templates/options.erb
@@ -1,5 +1,5 @@
 Dpkg::Options {
-<%- @_options.each_pair do |config, value| 
+<%- @_options.sort_by{|key,value| key}.each do |config, value|
   if %w(force_confdef force_confold force_confnew force_confmiss).include?(config) then
     if value then -%>
   "--<%= config.sub('_','-') -%>";


### PR DESCRIPTION
We got a lot of

`Tue Nov 01 09:14:43 +0100 2016 /Stage[main]/Unattended_upgrades/Apt::Conf[options]/Apt::Setting[conf-options]/File[/etc/apt/apt.conf.d/10options]/content (notice): content changed '{md5}3223a58b66433a63aab1c2bb3467eb0c' to '{md5}5812e79a8e013327aba71e43f1ea3725'`

Fixing the order of options fixes it. 

I ran the tests, they all pass. I didn't create a new test because I don't know how to test for the order of lines. 