### PR TITLE
Include the release pocket on Ubuntu Xenial and Yakkety.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class unattended_upgrades::params {
         'xenial', 'yakkety': {
           $legacy_origin      = true
           $origins            = [
+            '${distro_id}:${distro_codename}', #lint:ignore:single_quote_string_with_variables
             '${distro_id}:${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
           ]
         }

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -316,6 +316,7 @@ describe 'unattended_upgrades' do
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"\${distro_id}\:\${distro_codename}";\n
         \t"\${distro_id}\:\${distro_codename}-security";\n
         };/x
       )
@@ -339,6 +340,7 @@ describe 'unattended_upgrades' do
       ).with_content(
         # This is the only section that's different for Ubuntu compared to Debian
         /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"\${distro_id}\:\${distro_codename}";\n
         \t"\${distro_id}\:\${distro_codename}-security";\n
         };/x
       )


### PR DESCRIPTION
As per https://bugs.launchpad.net/ubuntu/+source/unattended-upgrades/+bug/1624641 the `release` pocket should be included to allow additional dependencies to be installed if required by a security update.

This change has been released to `yakkety` and backported to `xenial`