### PR TITLE
Bump min version_requirement for Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions