### PR TITLE
Allow newer apt modules to satisfy dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
The newer 3.x and 4.x versions of the apt module are backwards
compatible and remove some calls to deprecated functions and add new
features.

This allows this module to be used alongside other modules that require
the newer apt module's features.