### PR TITLE
Create init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,9 @@ class unattended_upgrades (
   Boolean                                   $notify_update        = false,
   Unattended_upgrades::Options              $options              = {},
 ) inherits ::unattended_upgrades::params {
+    
+  contain apt
+
   $_age = merge($::unattended_upgrades::default_age, $age)
   assert_type(Unattended_upgrades::Age, $_age)
 


### PR DESCRIPTION
Fix Error while evaluating a Resource Statement, Evaluation Error: Operator '[]' is not applicable to an Undef Value"
<!--
Issue https://github.com/voxpupuli/puppet-unattended_upgrades/issues/92


Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Operator '[]' is not applicable to an Undef Value. at /etc/puppetlabs/code/environments/production/modules/apt/manifests/setting.pp:35:12 at /etc/puppetlabs/code/environments/production/modules/apt/manifests/conf.pp:15 on node 


