### PR TITLE
Wheezy is now oldoldstable, jessie oldstable and stretch stable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class unattended_upgrades::params {
       case $xfacts['lsbdistcodename'] {
         'squeeze': {
           $legacy_origin       = true
-          $origins             =  '${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+          $origins             =  ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
                                   '${distro_id} ${distro_codename}-lts',] #lint:ignore:single_quote_string_with_variables
         }
         'wheezy': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,14 +50,18 @@ class unattended_upgrades::params {
       case $xfacts['lsbdistcodename'] {
         'squeeze': {
           $legacy_origin       = true
-          $origins             = ['${distro_id} oldoldstable', #lint:ignore:single_quote_string_with_variables
-                                  '${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+          $origins             =  '${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
                                   '${distro_id} ${distro_codename}-lts',] #lint:ignore:single_quote_string_with_variables
         }
         'wheezy': {
           $legacy_origin      = false
           $origins            = [
-            'origin=Debian,archive=stable,label=Debian-Security',
+            'origin=Debian,archive=oldoldstable,label=Debian-Security',
+          ]
+        }
+        'jessie': {
+          $legacy_origin      = false
+          $origins            = [
             'origin=Debian,archive=oldstable,label=Debian-Security',
           ]
         }

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -150,7 +150,6 @@ describe 'unattended_upgrades' do
       ).with_content(
         # This section varies for different releases
         /\Unattended-Upgrade::Allowed-Origins\ {\n
-        \t"\${distro_id}\ oldoldstable";\n
         \t"\${distro_id}\ \${distro_codename}-security";\n
         \t"\${distro_id}\ \${distro_codename}-lts";\n
         };/x
@@ -176,8 +175,7 @@ describe 'unattended_upgrades' do
       ).with_content(
         # This section varies for different releases
         /\Unattended-Upgrade::Origins-Pattern\ {\n
-        \t"origin=Debian,archive=stable,label=Debian-Security";\n
-        \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+        \t"origin=Debian,archive=oldoldstable,label=Debian-Security";\n
         };/x
       )
     end
@@ -190,6 +188,30 @@ describe 'unattended_upgrades' do
         lsbdistid: 'Debian',
         lsbdistcodename: 'jessie',
         lsbdistrelease: '8.2'
+      }
+    end
+
+    it do
+      is_expected.to create_file(file_unattended).with(
+        owner: 'root',
+        group: 'root',
+        mode: '0644'
+      ).with_content(
+        # This section varies for different releases
+        /\Unattended-Upgrade::Origins-Pattern\ {\n
+        \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+        };/x
+      )
+    end
+  end
+
+  context 'with defaults on Debian 9 Stretch' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        lsbdistid: 'Debian',
+        lsbdistcodename: 'stretch',
+        lsbdistrelease: '9.0'
       }
     end
 


### PR DESCRIPTION
As Stretch is the new stable, the older release have become older in names too.
Squeeze is no longer present at the security.debian.org repo as there is no `oldoldoldstable`.

Without this change it will no longer install the updates unattended.