### PR TITLE
Update Debian upstream names

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,14 +50,18 @@ class unattended_upgrades::params {
       case $xfacts['lsbdistcodename'] {
         'squeeze': {
           $legacy_origin       = true
-          $origins             = ['${distro_id} oldoldstable', #lint:ignore:single_quote_string_with_variables
-                                  '${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+          $origins             =  ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
                                   '${distro_id} ${distro_codename}-lts',] #lint:ignore:single_quote_string_with_variables
         }
         'wheezy': {
           $legacy_origin      = false
           $origins            = [
-            'origin=Debian,archive=stable,label=Debian-Security',
+            'origin=Debian,archive=oldoldstable,label=Debian-Security',
+          ]
+        }
+        'jessie': {
+          $legacy_origin      = false
+          $origins            = [
             'origin=Debian,archive=oldstable,label=Debian-Security',
           ]
         }

--- a/metadata.json
+++ b/metadata.json
@@ -13,7 +13,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -92,7 +92,6 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Allowed-Origins\ {\n
-                \t"\${distro_id}\ oldoldstable";\n
                 \t"\${distro_id}\ \${distro_codename}-security";\n
                 \t"\${distro_id}\ \${distro_codename}-lts";\n
                 };/x
@@ -109,8 +108,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,archive=stable,label=Debian-Security";\n
-                \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+                \t"origin=Debian,archive=oldoldstable,label=Debian-Security";\n
                 };/x
               )
             end
@@ -125,10 +123,25 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                  \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
-                  };/x
+                \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+                };/x
               )
             end
+          end
+        end
+      when 'stretch'
+        context 'with defaults on Debian 9 Stretch' do
+          it do
+            is_expected.to create_file(file_unattended).with(
+              owner: 'root',
+              group: 'root',
+              mode: '0644'
+            ).with_content(
+              # This section varies for different releases
+              /\Unattended-Upgrade::Origins-Pattern\ {\n
+              \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+              };/x
+            )
           end
         end
       end


### PR DESCRIPTION
* Wheezy is now oldoldstable
* jessie oldstable
* stretch stable
* Add Stretch to supported releases

Rebase of #97 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
