### PR TITLE
Adds Debian 9 - Stretch Support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,6 +65,12 @@ class unattended_upgrades::params {
             'origin=Debian,archive=oldstable,label=Debian-Security',
           ]
         }
+        'stretch': {
+          $legacy_origin      = false
+          $origins            = [
+            'origin=Debian,archive=stable,label=Debian-Security',
+          ]
+        }
         default: {
           $legacy_origin      = false
           $origins            = ['origin=Debian,codename=${distro_codename},label=Debian-Security',] #lint:ignore:single_quote_string_with_variables

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -78,9 +78,9 @@ describe 'unattended_upgrades' do
                     path: '/usr/lib64/qt-3.3/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin')
       end
 
-      case facts[:operatingsystem]
-      when 'Debian'
+      if facts[:operatingsystem] == 'Debian'
         it_behaves_like 'Debian specs'
+
         case facts[:lsbdistcodename]
         when 'squeeze'
           context 'with defaults on Debian 6 Squeeze' do
@@ -128,23 +128,58 @@ describe 'unattended_upgrades' do
               )
             end
           end
-        end
-      when 'stretch'
-        context 'with defaults on Debian 9 Stretch' do
-          it do
-            is_expected.to create_file(file_unattended).with(
-              owner: 'root',
-              group: 'root',
-              mode: '0644'
-            ).with_content(
-              # This section varies for different releases
-              /\Unattended-Upgrade::Origins-Pattern\ {\n
-              \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
-              };/x
-            )
+        # Won't work until FacterDB adds Stretch support
+        when 'stretch'
+          context 'with defaults on Debian 9 Stretch' do
+            it do
+              is_expected.to create_file(file_unattended).with(
+                owner: 'root',
+                group: 'root',
+                mode: '0644'
+              ).with_content(
+                # This section varies for different releases
+                /\Unattended-Upgrade::Origins-Pattern\ {\n
+                \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+                };/x
+              )
+            end
           end
         end
       end
+    end
+  end
+
+  # Adding Stretch Spec until FacterDB adds Stretch
+  context 'with defaults on Debian 9 Stretch' do
+    let(:facts) do
+      {
+        osfamily: 'Debian',
+        lsbdistid: 'Debian',
+        os: {
+          name: 'Debian',
+          family: 'Debian',
+          release: {
+            full: '9.0'
+          }
+        },
+        lsbdistcodename: 'stretch',
+        lsbrelease: '9.0'
+      }
+    end
+
+    it_behaves_like 'Debian specs'
+
+    it do
+      is_expected.to create_file(file_unattended).with(
+        owner: 'root',
+        group: 'root',
+        mode: '0644'
+      ).with_content(
+        # This section varies for different releases
+        /\Unattended-Upgrade::Origins-Pattern\ {\n
+        \t"origin=Debian,archive=stable,label=Debian-Security";\n
+        };/x
+      )
     end
   end
 end


### PR DESCRIPTION
* Stretch is now stable
* Add Stretch to metadata.json
* Updates specs (Waiting in FacterDB support)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
