### PR TITLE
Adds ::apt containment to main class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@ class unattended_upgrades (
   Boolean                                   $notify_update        = false,
   Unattended_upgrades::Options              $options              = {},
 ) inherits ::unattended_upgrades::params {
+
+  # apt::conf settings require the apt class to work
+  contain ::apt
+
   $_age = merge($::unattended_upgrades::default_age, $age)
   assert_type(Unattended_upgrades::Age, $_age)
 

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -6,10 +6,6 @@ describe 'unattended_upgrades' do
   let(:file_periodic) { '/etc/apt/apt.conf.d/10periodic' }
   let(:file_options) { '/etc/apt/apt.conf.d/10options' }
 
-  let(:pre_condition) do
-    'include ::apt'
-  end
-
   shared_examples 'Debian specs' do
     let(:params) { {} }
 

--- a/spec/classes/other_debians_spec.rb
+++ b/spec/classes/other_debians_spec.rb
@@ -4,10 +4,6 @@ describe 'unattended_upgrades' do
   let(:file_periodic) { '/etc/apt/apt.conf.d/10periodic' }
   let(:file_options) { '/etc/apt/apt.conf.d/10options' }
 
-  let(:pre_condition) do
-    'include ::apt'
-  end
-
   context 'with defaults on Raspbian' do
     let(:facts) do
       {

--- a/spec/classes/ubuntu_spec.rb
+++ b/spec/classes/ubuntu_spec.rb
@@ -6,10 +6,6 @@ describe 'unattended_upgrades' do
   let(:file_periodic) { '/etc/apt/apt.conf.d/10periodic' }
   let(:file_options) { '/etc/apt/apt.conf.d/10options' }
 
-  let(:pre_condition) do
-    'include ::apt'
-  end
-
   shared_examples 'Ubuntu specs' do
     let(:params) { {} }
 

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -6,10 +6,6 @@ describe 'unattended_upgrades' do
   let(:file_periodic) { '/etc/apt/apt.conf.d/10periodic' }
   let(:file_options) { '/etc/apt/apt.conf.d/10options' }
 
-  let(:pre_condition) do
-    'include ::apt'
-  end
-
   shared_examples 'basic specs' do
     let(:params) { {} }
 
@@ -21,6 +17,7 @@ describe 'unattended_upgrades' do
         is_expected.to compile.with_all_deps
         is_expected.to contain_class('unattended_upgrades::params')
         is_expected.to contain_class('unattended_upgrades')
+        is_expected.to contain_class('apt')
       end
 
       it do


### PR DESCRIPTION
* Since the class won't work without apt, makes
sense to add it as a contained class
* Adds specs

Replaces #96 #94
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
