### PR TITLE
Optional argument for specifing the Unattended-Upgrade::Sender config flag

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class unattended_upgrades (
   Array                                     $origins              = $::unattended_upgrades::params::origins,
   String                                    $package_ensure       = installed,
   Optional[Integer[0]]                      $random_sleep         = undef,
+  Optional[String]                          $sender               = undef,
   Integer[0]                                $size                 = 0,
   Integer[0]                                $update               = 1,
   Integer[0]                                $upgrade              = 1,

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -70,6 +70,7 @@ describe 'unattended_upgrades' do
             'to'            => 'root@localhost',
             'only_on_error' => true
           },
+          sender: 'root@server.example.com',
           dl_limit: 70,
           random_sleep: 300,
           notify_update: true,
@@ -128,6 +129,8 @@ describe 'unattended_upgrades' do
           /Unattended-Upgrade::Automatic-Reboot-Time "03:00";/
         ).with_content(
           /Unattended-Upgrade::Mail "root@localhost";/
+        ).with_content(
+          /Unattended-Upgrade::Sender "root@server.example.com";/
         ).with_content(
           /Unattended-Upgrade::MailOnlyOnError "true";/
         ).with_content(

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -40,6 +40,8 @@ describe 'unattended_upgrades' do
           notify_update: false
         )
       end
+
+      it { is_expected.to create_file(file_unattended).without_content(/Unattended-Upgrade::Sender/) }
     end
 
     context 'set all the things' do

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -52,12 +52,12 @@ Unattended-Upgrade::MailOnlyOnError "<%= @_mail['only_on_error'].to_s %>";
 <%- end -%>
 <%- end -%>
 
-<%- unless @sender.nil? -%>
+<%- if @sender -%>
 // Use the specified value in the "From" field of outgoing mails.
 // Defaults to "root"
 Unattended-Upgrade::Sender "<%= @sender %>";
-<%- end -%>
 
+<%- end -%>
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "<%= @_auto['remove'].to_s %>";

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -52,6 +52,12 @@ Unattended-Upgrade::MailOnlyOnError "<%= @_mail['only_on_error'].to_s %>";
 <%- end -%>
 <%- end -%>
 
+<%- unless @sender.nil? -%>
+// Use the specified value in the "From" field of outgoing mails.
+// Defaults to "root"
+Unattended-Upgrade::Sender "<%= @sender %>";
+<%- end -%>
+
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "<%= @_auto['remove'].to_s %>";


### PR DESCRIPTION
Added the $sender argument to allow specifing a non-default Unattended-Upgrade::Sender configuration flag in 50unattended-upgrades file. Should solve issue #119 
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

Fixes #119 