### PR TITLE
Support support for the KDE Neon distribution

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,7 @@ class unattended_upgrades::params {
         }
       }
     }
-    'ubuntu': {
+    'ubuntu', 'neon': {
       case $xfacts['lsbdistcodename'] {
         'precise': {
           $legacy_origin      = true


### PR DESCRIPTION
#### Pull Request (PR) description

This pull request add support for _KDE Neon_, an Ubuntu derivative from the KDE project.
https://neon.kde.org/

The patch was made by @neomilium (an @opus-codium coworker) who apparently forgot to open a pull-request upstream :wink: I'm doing it for him in order to avoid forgetting about this.

#### This Pull Request (PR) fixes the following issues

n/a
