### PR TITLE
Add support for Unattended-Upgrade::Update-Days

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ altering some of the default settings.
 * `size` (`0`): Maximum size of the cache in MB.
 * `update` (`1`): Do "apt-get update" automatically every n-days.
 * `upgrade` (`1`): Run the "unattended-upgrade" security upgrade script every n-days.
+* `days` (`[]`): Set the days of the week that updates should be applied. The days can be specified as localized abbreviated or full names. Or as integers where "0" is Sunday, "1" is Monday etc.
 * `upgradeable_packages` (`{}`): A hash with two possible keys:
   * `download_only` (`0`): Do "apt-get upgrade --download-only" every n-days.
   * `debdelta` (`1`): Use debdelta-upgrade to download updates if available.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class unattended_upgrades (
   Integer[0]                                $verbose              = 0,
   Boolean                                   $notify_update        = false,
   Unattended_upgrades::Options              $options              = {},
+  Array[String[1]]                          $days                 = [],
 ) inherits ::unattended_upgrades::params {
 
   # apt::conf settings require the apt class to work

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -55,6 +55,7 @@ describe 'unattended_upgrades' do
             'debdelta'      => 5
           },
           upgrade: 5,
+          days: %w[tuesday Thursday 5],
           auto: {
             'clean'                => 5,
             'fix_interrupted_dpkg' => false,
@@ -117,6 +118,8 @@ describe 'unattended_upgrades' do
           /Unattended-Upgrade::Allowed-Origins {\n\t"bananas";\n};/
         ).with_content(
           /Unattended-Upgrade::Package-Blacklist {\n\t"foo";\n\t"bar";\n};/
+        ).with_content(
+          /Unattended-Upgrade::Update-Days {\n\t"Tuesday";\n\t"Thursday";\n\t"5";\n};/
         ).with_content(
           /Unattended-Upgrade::AutoFixInterruptedDpkg "false";/
         ).with_content(
@@ -203,6 +206,19 @@ describe 'unattended_upgrades' do
         let :params do
           {
             install_on_shutdown: 'foo'
+          }
+        end
+
+        it do
+          expect do
+            subject.call
+          end.to raise_error(Puppet::Error, /got String/)
+        end
+      end
+      context 'bad days' do
+        let :params do
+          {
+            days: 'foo'
           }
         end
 

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -20,6 +20,16 @@ Unattended-Upgrade::Package-Blacklist {
 <% end -%>
 };
 
+// List of days in the week that updates should be applied.
+// The days can be specified as localized abbreviated or full names.
+// Or as integers where "0" is Sunday, "1" is Monday etc.
+// Require Unattended-upgrades version >=0.91 to work, else it is ignored
+Unattended-Upgrade::Update-Days {
+<% @days.each do |day| -%>
+	"<%= day.capitalize %>";
+<% end -%>
+};
+
 // This option allows you to control if on a unclean dpkg exit
 // unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a


### PR DESCRIPTION

#### Pull Request (PR) description
Unattended-upgrades have added support for Update-Days with the setting
`Unattended-Upgrade::Update-Days {"Mon";"Fri"};` 
This was added in git commit https://github.com/mvo5/unattended-upgrades/commit/3b27c5aec55d8f4360778bc351a1c61f1ae1e1ff and included in unattended-upgrades version 0.91
