### PR TITLE
Allow additional origins without replacing the default one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ altering some of the default settings.
 * `minimal_steps` (`true`): Split the upgrade process into sections to allow
   shutdown during upgrade.
 * `origins`: The repositories from which to automatically upgrade included packages.
+* `extra_origins`: Additional repositories from which upgrades should be included. Can be used, if the default `origins` should be kept.
 * `package_ensure` (`installed`): The ensure state for the 'unattended-upgrades'
   package.
 * `random_sleep` (`undef`): Maximum amount of time (in seconds) that the apt cron

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class unattended_upgrades (
   Unattended_upgrades::Mail                 $mail                 = {},
   Boolean                                   $minimal_steps        = true,
   Array                                     $origins              = $::unattended_upgrades::params::origins,
+  Array                                     $extra_origins        = {},
   String                                    $package_ensure       = installed,
   Optional[Integer[0]]                      $random_sleep         = undef,
   Optional[String]                          $sender               = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class unattended_upgrades (
   Unattended_upgrades::Mail                 $mail                 = {},
   Boolean                                   $minimal_steps        = true,
   Array                                     $origins              = $::unattended_upgrades::params::origins,
-  Array                                     $extra_origins        = {},
+  Array                                     $extra_origins        = [],
   String                                    $package_ensure       = installed,
   Optional[Integer[0]]                      $random_sleep         = undef,
   Optional[String]                          $sender               = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class unattended_upgrades (
   Unattended_upgrades::Mail                 $mail                 = {},
   Boolean                                   $minimal_steps        = true,
   Array                                     $origins              = $::unattended_upgrades::params::origins,
-  Array                                     $extra_origins        = [],
+  Array[String[1]]                          $extra_origins        = [],
   String                                    $package_ensure       = installed,
   Optional[Integer[0]]                      $random_sleep         = undef,
   Optional[String]                          $sender               = undef,

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -11,6 +11,9 @@ Unattended-Upgrade::Origins-Pattern {
 <% @origins.each do |origin| -%>
 	"<%= origin %>";
 <% end -%>
+<% @extra_origins.each do |origin| -%>
+	"<%= origin %>";
+<% end -%>
 };
 
 // List of packages to not update (regexp are supported)


### PR DESCRIPTION
#### Pull Request (PR) description
This PR enables the users to specify extra origins, in order to have a combination of the automatic default origins and further origins.

#### This Pull Request (PR) fixes the following issues
This does not fix, but refers, to #105 