### PR TITLE
 Open version dependencies 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 <= 7.0.1"
+      "version_requirement": ">= 2.2.0 < 7.1.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 < 7.0.0"
+      "version_requirement": ">= 2.2.0 <= 7.0.1"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.2.0 < 7.1.0"
+      "version_requirement": ">= 2.2.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
This morning i ran in various dependency problems because i have some modules which request release 7.0.1 of puppetlabs-apt.
This change opens the dependency a bit.