### PR TITLE
 * fix: debian origins since archive name changes, moved to codename …

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,28 +48,10 @@ class unattended_upgrades::params {
   case $xfacts['lsbdistid'] {
     'debian', 'raspbian': {
       case $xfacts['lsbdistcodename'] {
-        'squeeze': {
-          $legacy_origin       = true
+        'squeeze', 'wheezy': {
+          $legacy_origin      = true
           $origins             =  ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
                                   '${distro_id} ${distro_codename}-lts',] #lint:ignore:single_quote_string_with_variables
-        }
-        'wheezy': {
-          $legacy_origin      = false
-          $origins            = [
-            'origin=Debian,archive=oldoldstable,label=Debian-Security',
-          ]
-        }
-        'jessie': {
-          $legacy_origin      = false
-          $origins            = [
-            'origin=Debian,archive=oldstable,label=Debian-Security',
-          ]
-        }
-        'stretch': {
-          $legacy_origin      = false
-          $origins            = [
-            'origin=Debian,archive=stable,label=Debian-Security',
-          ]
         }
         default: {
           $legacy_origin      = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,12 +50,23 @@ class unattended_upgrades::params {
       case $xfacts['lsbdistcodename'] {
         'squeeze', 'wheezy': {
           $legacy_origin      = true
-          $origins             =  ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
-                                  '${distro_id} ${distro_codename}-lts',] #lint:ignore:single_quote_string_with_variables
+          $origins            = [
+            '${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+            '${distro_id} ${distro_codename}-lts', #lint:ignore:single_quote_string_with_variables
+          ]
+        }
+        'buster': {
+          $legacy_origin      = false
+          $origins            = [
+            'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
+            'origin=Debian,codename=${distro_codename},label=Debian-Security', #lint:ignore:single_quote_string_with_variables
+          ]
         }
         default: {
           $legacy_origin      = false
-          $origins            = ['origin=Debian,codename=${distro_codename},label=Debian-Security',] #lint:ignore:single_quote_string_with_variables
+          $origins            = [
+            'origin=Debian,codename=${distro_codename},label=Debian-Security', #lint:ignore:single_quote_string_with_variables
+          ]
         }
       }
     }

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -140,7 +140,6 @@ describe 'unattended_upgrades' do
               )
             end
           end
-        end
         when 'buster'
           context 'with defaults on Debian 10 Buster' do
             it do

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -150,6 +150,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
+                \t"origin=Debian,codename=\${distro_codename},label=Debian";\n
                 \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
                 };/x
               )

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -103,8 +103,9 @@ describe 'unattended_upgrades' do
                 mode: '0644'
               ).with_content(
                 # This section varies for different releases
-                /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,archive=oldoldstable,label=Debian-Security";\n
+                /\Unattended-Upgrade::Allowed-Origins\ {\n
+                \t"\${distro_id}\ \${distro_codename}-security";\n
+                \t"\${distro_id}\ \${distro_codename}-lts";\n
                 };/x
               )
             end
@@ -119,7 +120,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,archive=oldstable,label=Debian-Security";\n
+                \t"origin=Debian,codename=jessie,label=Debian-Security";\n
                 };/x
               )
             end
@@ -134,7 +135,23 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,archive=stable,label=Debian-Security";\n
+                \t"origin=Debian,codename=stretch,label=Debian-Security";\n
+                };/x
+              )
+            end
+          end
+        end
+        when 'buster'
+          context 'with defaults on Debian 10 Buster' do
+            it do
+              is_expected.to create_file(file_unattended).with(
+                owner: 'root',
+                group: 'root',
+                mode: '0644'
+              ).with_content(
+                # This section varies for different releases
+                /\Unattended-Upgrade::Origins-Pattern\ {\n
+                \t"origin=Debian,codename=buster,label=Debian-Security";\n
                 };/x
               )
             end

--- a/spec/classes/debian_spec.rb
+++ b/spec/classes/debian_spec.rb
@@ -120,7 +120,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,codename=jessie,label=Debian-Security";\n
+                \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
                 };/x
               )
             end
@@ -135,7 +135,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,codename=stretch,label=Debian-Security";\n
+                \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
                 };/x
               )
             end
@@ -150,7 +150,7 @@ describe 'unattended_upgrades' do
               ).with_content(
                 # This section varies for different releases
                 /\Unattended-Upgrade::Origins-Pattern\ {\n
-                \t"origin=Debian,codename=buster,label=Debian-Security";\n
+                \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
                 };/x
               )
             end


### PR DESCRIPTION
…based filter for future proofing #145

#### Pull Request (PR) description
Debian changed apt repository archive names some weeks ago, this PR adapts the module to that and switches to codename (jessie/stretch/buster etc.) based origin filtering for debian based systems, so it should be more stable in the future.

#### This Pull Request (PR) fixes the following issues
Fixes #145 
