### PR TITLE
Changed typo archive_internal to archive_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ altering some of the default settings.
   ```
 
 * `backup` (`{}`): A hash with two possible keys:
-  * `archive_internal` (`0`): Backup after n-days if archive contents changed.
+  * `archive_interval` (`0`): Backup after n-days if archive contents changed.
   * `level` (`3`): Backup level.
 
   Any of these keys can be specified and will be merged into the defaults:


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
In the Readme.md the attribute for backup archive_interval was listed as archive_internal
-->

#### This Pull Request (PR) fixes the following issues
<!--
#155 Fixes: archive_internal typo in readme
-->
