### PR TITLE
Drop EOL Linux Mint versions 13 and 17

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,20 +43,6 @@ class unattended_upgrades::params {
     }
     'LinuxMint': {
       case fact('lsbmajdistrelease') {
-        # Linux Mint 13 is based on Ubuntu 12.04
-        '13': {
-          $legacy_origin      = true
-          $origins            = [
-            'Ubuntu:precise-security',
-          ]
-        }
-        # Linux Mint 17* is based on Ubuntu 14.04.
-        '17': {
-          $legacy_origin      = true
-          $origins            = [
-            'Ubuntu:trusty-security',
-          ]
-        }
         # Linux Mint 18* is based on Ubuntu 16.04
         '18': {
           $legacy_origin      = true

--- a/spec/classes/other_debians_spec.rb
+++ b/spec/classes/other_debians_spec.rb
@@ -29,68 +29,6 @@ describe 'unattended_upgrades' do
     end
   end
 
-  context 'with defaults on Linux Mint 13 Maya' do
-    let(:facts) do
-      {
-        os: {
-          name: 'LinuxMint',
-          family: 'Debian',
-          release: {
-            full: '13'
-          }
-        },
-        osfamily: 'Debian',
-        lsbdistid: 'LinuxMint',
-        lsbdistcodename: 'maya',
-        lsbdistrelease: '13',
-        lsbmajdistrelease: '13'
-      }
-    end
-
-    it do
-      is_expected.to create_file(file_unattended).with(
-        'owner' => 'root',
-        'group' => 'root'
-      ).with_content(
-        # This is the only section that's different for Ubuntu compared to Debian
-        %r{\Unattended-Upgrade::Allowed-Origins\ {\n
-        \t"Ubuntu\:precise-security";\n
-        };}x
-      )
-    end
-  end
-
-  context 'with defaults on Linux Mint 17.3 Rosa' do
-    let(:facts) do
-      {
-        os: {
-          name: 'LinuxMint',
-          family: 'Debian',
-          release: {
-            full: '17.3'
-          }
-        },
-        osfamily: 'Debian',
-        lsbdistid: 'LinuxMint',
-        lsbdistcodename: 'rosa',
-        lsbdistrelease: '17.3',
-        lsbmajdistrelease: '17'
-      }
-    end
-
-    it do
-      is_expected.to create_file(file_unattended).with(
-        'owner' => 'root',
-        'group' => 'root'
-      ).with_content(
-        # This is the only section that's different for Ubuntu compared to Debian
-        %r{\Unattended-Upgrade::Allowed-Origins\ {\n
-        \t"Ubuntu\:trusty-security";\n
-        };}x
-      )
-    end
-  end
-
   context 'with defaults on Linux Mint 18 Sarah' do
     let(:facts) do
       {


### PR DESCRIPTION
It's odd we don't list Linux Mint in metadata.json yet have code for it.