### PR TITLE
Revert "Add Puppet management headers in the config files"

### DIFF
--- a/templates/periodic.erb
+++ b/templates/periodic.erb
@@ -1,5 +1,3 @@
-# This file managed by Puppet
-#
 APT::Periodic::Enable "<%= @enable %>";
 #  - Enable the update/upgrade script (0=disable)
 #

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -1,5 +1,3 @@
-// This file managed by Puppet
-
 // Automatically upgrade packages from these (origin:archive) pairs
 //
 // Note that in Ubuntu security updates may pull in new dependencies


### PR DESCRIPTION
Reverts voxpupuli/puppet-unattended_upgrades#162

As noted in https://github.com/voxpupuli/puppet-unattended_upgrades/pull/162#issuecomment-648634680 the puppetlabs-apt module already [set](https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/_header.epp) [headers](https://github.com/puppetlabs/puppetlabs-apt/blob/master/templates/_conf_header.epp) for configuration files fragments.