### PR TITLE
Support Ubuntu Extended Security Maintenance (ESM)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,8 @@ class unattended_upgrades::params {
       $origins            = [
         '${distro_id}:${distro_codename}', #lint:ignore:single_quote_string_with_variables
         '${distro_id}:${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+        '${distro_id}ESMApps:${distro_codename}-apps-security', #lint:ignore:single_quote_string_with_variables
+        '${distro_id}ESM:${distro_codename}-infra-security', #lint:ignore:single_quote_string_with_variables
       ]
     }
     'LinuxMint': {

--- a/spec/classes/os_spec.rb
+++ b/spec/classes/os_spec.rb
@@ -69,6 +69,8 @@ describe 'unattended_upgrades' do
             /Unattended-Upgrade::Allowed-Origins\ {\n
             \t"\${distro_id}\:\${distro_codename}";\n
             \t"\${distro_id}\:\${distro_codename}-security";\n
+            \t"\${distro_id}ESMApps\:\${distro_codename}-apps-security";\n
+            \t"\${distro_id}ESM\:\${distro_codename}-infra-security";\n
             };/x
           )
         end


### PR DESCRIPTION
> Extended Security Maintenance; doesn't necessarily exist for
> every release and this system may not have it installed, but if
> available, the policy for updates is such that unattended-upgrades
> should also install from here by default.

Signed-off-by: Raoul Bhatia <raoul@bhatia.at>