### PR TITLE
add SyslogEnable and SyslogFacility options to unattended-upgrades.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ altering some of the default settings.
   * `force_confmiss` (`false`): Always install missing config files
 * `remove_new_unused_deps` (`undef`): Automatic removal of newly unused dependencies after the upgrade.
 * `remove_unused_kernel` (`undef`): Remove unused automatically installed kernel-related packages.
+* `syslog_enable` (`undef`): Enable logging to syslog. Default is False.
+* `syslog_facility` (`undef`): Specify syslog facility. Default is `daemon`.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,6 +24,8 @@ class unattended_upgrades (
   Array[String[1]]                          $days                   = [],
   Optional[Boolean]                         $remove_unused_kernel   = undef,
   Optional[Boolean]                         $remove_new_unused_deps = undef,
+  Optional[Boolean]                         $syslog_enable          = undef,
+  Optional[String]                          $syslog_facility        = undef,
 ) inherits ::unattended_upgrades::params {
   # apt::conf settings require the apt class to work
   include apt

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -83,7 +83,9 @@ describe 'unattended_upgrades' do
             'force_confnew' =>  true,
             'force_confmiss' => true
           },
-          remove_new_unused_deps: false
+          remove_new_unused_deps: false,
+          syslog_enable: true,
+          syslog_facility: 'daemon',
         }
       end
 
@@ -144,6 +146,10 @@ describe 'unattended_upgrades' do
           /Unattended-Upgrade::Remove-New-Unused-Dependencies "false";/
         ).without_content(
           /Unattended-Upgrade::Remove-Unused-Kernel-Packages/
+        ).with_content(
+          /Unattended-Upgrade::SyslogEnable "true";/
+        ).with_content(
+          /Unattended-Upgrade::SyslogFacility "daemon";/
         )
       end
 

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -100,3 +100,13 @@ Unattended-Upgrade::Automatic-Reboot-Time "<%= @_auto['reboot_time'].to_s %>";
 // speed to 70kb/sec
 Acquire::http::Dl-Limit "<%= @dl_limit %>";
 <%- end -%>
+
+<%- unless @syslog_enable.nil? -%>
+// Enable logging to syslog. Default is False
+Unattended-Upgrade::SyslogEnable "<%= @syslog_enable %>";
+<%- end -%>
+
+<%- unless @syslog_facility.nil? -%>
+// Specify syslog facility. Default is daemon
+Unattended-Upgrade::SyslogFacility "<%= @syslog_facility %>";
+<%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Add the ability to configure the SyslogEnable and SyslogFacility options. See https://github.com/mvo5/unattended-upgrades/blob/master/README.md for reference.