### PR TITLE
disable by default and deprecate dpkg "options" parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,9 @@ class unattended_upgrades (
   $_upgradeable_packages = merge($unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)
   assert_type(Unattended_upgrades::Upgradeable_packages, $_upgradeable_packages)
 
+  if $options != {} {
+    warning('passing "options" is deprecated, use apt::conf directly instead')
+  }
   $_options = merge($unattended_upgrades::default_options, $options)
   assert_type(Unattended_upgrades::Options, $_options)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,9 +9,10 @@ class unattended_upgrades::params {
   $default_backup               = { 'archive_interval'     => 0, 'level'     => 3, }
   $default_age                  = { 'min'                  => 2, 'max'       => 0, }
   $default_upgradeable_packages = { 'download_only'        => 0, 'debdelta'  => 1, }
+  # those are DEPRECATED and will be removed in a future releaseq
   $default_options              = {
-    'force_confdef'        => true,
-    'force_confold'        => true,
+    'force_confdef'        => false,
+    'force_confold'        => false,
     'force_confnew'        => false,
     'force_confmiss'       => false,
   }

--- a/spec/classes/os_spec.rb
+++ b/spec/classes/os_spec.rb
@@ -33,8 +33,8 @@ describe 'unattended_upgrades' do
           with_owner('root').
           with_group('root').
           with_content(%r{^Dpkg::Options\s\{}).
-          with_content(%r{^\s+\"--force-confdef\";}).
-          with_content(%r{^\s+\"--force-confold\";}).
+          without_content(%r{^\s+\"--force-confdef\";}).
+          without_content(%r{^\s+\"--force-confold\";}).
           without_content(%r{\"--force-confnew\";}).
           without_content(%r{\"--force-confmiss\";})
       end


### PR DESCRIPTION
unattended-upgrades does *not* need special configuration to `dpkg`
for proper operation. It handles those itself. All that parameter does
is changes the `dpkg` configuration for *other* `dpkg` runs.

This will, for example, affect major upgrades, typically done by hand,
and not unattended-upgrades, which was *not* designed for that
purpose. In those cases, unsuspecting users will see their old
configuration file versions silently kept in place, which most
definitely *will* break things on upgrade, rather noisily in the end.

People unfamiliar with this mechanism will have a hard time figuring
out what has happened, and while recovery is possible, it is tricky
without special tooling. I wrote such a tool here:

https://gitlab.com/anarcat/koumbit-scripts/-/blob/master/vps/clean_conflicts

... but it not well known and definitely not shipped with Debian by
default.

While it is nice that the unattended-upgrades module allows users to
change dpkg options, this can be more easily (and directly) done with
the `apt::conf` parameter in the first place.

This also marks the feature as deprecated. Once a proper deprecation
delay has passed, the code can be removed (with, for example, PR #190).

Replaces #190 for now.