### PR TITLE
params: debian default: re-add main origin

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@ class unattended_upgrades::params {
         default: {
           $legacy_origin      = false
           $origins            = [
+            'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
             'origin=Debian,codename=${distro_codename},label=Debian-Security', #lint:ignore:single_quote_string_with_variables
           ]
         }

--- a/spec/classes/os_spec.rb
+++ b/spec/classes/os_spec.rb
@@ -45,10 +45,11 @@ describe 'unattended_upgrades' do
       case os_facts[:operatingsystem]
       when 'Debian'
         case os_facts[:lsbdistcodename]
-        when 'stretch', 'buster'
+        when 'buster'
           it do
             is_expected.to create_file(file_unattended).with_content(
               /Unattended-Upgrade::Origins-Pattern\ {\n
+              \t"origin=Debian,codename=\${distro_codename},label=Debian";\n
               \t"origin=Debian,codename=\${distro_codename},label=Debian-Security";\n
               };/x
             )


### PR DESCRIPTION
In #193, `buster` was renamed to `bullseye`, which caused a regression for `buster`: the main "Debian" origin would now be removed. This commit restores that origin for the default Debian case.