### PR TITLE
README: remove legacy_origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ altering some of the default settings.
 * `enable` (`1`): Enable the automatic installation of updates.
 * `install_on_shutdown` (`false`): Install updates on shutdown instead of in the
   background.
-* `legacy_origin` (`true` for Debian (squeeze), Ubuntu (precise, trusty,
-  xenial, bionic and default), `false` for Debian (wheezy and default)):
-  Use the legacy `Unattended-Upgrade::Allowed-Origins` setting or the modern `Unattended-Upgrade::Origins-Pattern`.
 * `mail`: A hash to configure email behaviour with the following possible keys:
   * `report` (`undef`): Possible values are "always", "only-on-error" or "on-change". Defaults to "on-change". Note that "never" is achieved by not setting any `to` address.
   * `only_on_error` (`true`): Only send mail when something went wrong. Deprecated in unattended-upgrades 1.13 and newer in favor of `report`.


### PR DESCRIPTION
`legacy_origin` was removed in #204.