### PR TITLE
Add only_on_ac_power option to unattended-upgrades.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ altering some of the default settings.
 * `remove_unused_kernel` (`undef`): Remove unused automatically installed kernel-related packages.
 * `syslog_enable` (`undef`): Enable logging to syslog. Default is False.
 * `syslog_facility` (`undef`): Specify syslog facility. Default is `daemon`.
+* `only_on_ac_power` (`undef`): Download and install upgrades only on AC power. Default is `true`.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class unattended_upgrades (
   Optional[Boolean]                         $remove_new_unused_deps = undef,
   Optional[Boolean]                         $syslog_enable          = undef,
   Optional[String]                          $syslog_facility        = undef,
+  Optional[Boolean]                         $only_on_ac_power       = undef,
 ) inherits unattended_upgrades::params {
   # apt::conf settings require the apt class to work
   include apt

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -86,7 +86,8 @@ describe 'unattended_upgrades' do
           },
           remove_new_unused_deps: false,
           syslog_enable: true,
-          syslog_facility: 'daemon'
+          syslog_facility: 'daemon',
+          only_on_ac_power: false,
         }
       end
 
@@ -155,6 +156,8 @@ describe 'unattended_upgrades' do
           /Unattended-Upgrade::SyslogEnable "true";/
         ).with_content(
           /Unattended-Upgrade::SyslogFacility "daemon";/
+        ).with_content(
+          /Unattended-Upgrade::OnlyOnACPower "false";/
         )
       end
 

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -122,3 +122,9 @@ Unattended-Upgrade::SyslogEnable "<%= @syslog_enable %>";
 // Specify syslog facility. Default is daemon
 Unattended-Upgrade::SyslogFacility "<%= @syslog_facility %>";
 <%- end -%>
+
+<%- unless @only_on_ac_power.nil? -%>
+// Download and install upgrades only on AC power
+// (i.e. skip or gracefully stop updates on battery)
+Unattended-Upgrade::OnlyOnACPower "<%= @only_on_ac_power %>";
+<%- end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added an option to control whether unattended-upgrades are run only when AC power is connected.
This option is available in the package maintainers config file but wasn't previously controllable with this module.
Availability of this option will give the option to ensure updates are run on laptop devices, even if no AC power is connected.

Syntax and unit tests have been run successfully.
Had some trouble with beaker, so wasn't able to run the integration tests.

#### This Pull Request (PR) fixes the following issues
N/A
