### PR TITLE
types/origin: fix typo in comment

### DIFF
--- a/types/origin.pp
+++ b/types/origin.pp
@@ -1,2 +1,2 @@
-# @summary Validate that the given input is accepted as an `Unattended-Upgrade::Origin-Pattern`.
+# @summary Validate that the given input is accepted as an `Unattended-Upgrade::Origins-Pattern`.
 type Unattended_upgrades::Origin = Pattern[/^(origin|codename|label|site|suite|component|archive|[oalcn])=[^,]+(,(origin|codename|label|site|suite|component|archive|[oalcn])=[^,]+)*/]


### PR DESCRIPTION
It is Unattended-Upgrade::Origins-Pattern, "Origins", plural.

Reference: https://github.com/mvo5/unattended-upgrades