### PR TITLE
Add reboot_withusers option to unattended-upgrades.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ altering some of the default settings.
     Also supports 'always' as value to execute this operation every time the script is executed.
   * `fix_interrupted_dpkg`(`true`): Try to fix package installation state.
   * `reboot`(`false`): Reboot system after package update installation.
+  * `reboot_withusers`(`true`): If automatic reboot is enabled and needed, reboot even if there are users currently logged in.
   * `reboot_time`(`now`): If automatic reboot is enabled and needed, reboot at the
     specific time (instead of immediately). Expects a string in the format "HH:MM", using the 24 hour clock with leading zeros. Examples:  "16:37" for 37 minutes past 4PM, or "02:03" for 3 minutes past 2AM.
   * `remove`(`true`): Remove unneeded dependencies after update installation.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class unattended_upgrades::params {
     fail('This module only works on Debian or derivatives like Ubuntu')
   }
 
-  $default_auto                 = { 'fix_interrupted_dpkg' => true, 'remove' => true, 'reboot' => false, 'clean' => 0, 'reboot_time' => 'now', }
+  $default_auto                 = { 'fix_interrupted_dpkg' => true, 'remove' => true, 'reboot' => false, 'reboot_withusers' => true, 'clean' => 0, 'reboot_time' => 'now', }
   $default_mail                 = { 'only_on_error'        => true, }
   $default_backup               = { 'archive_interval'     => 0, 'level'     => 3, }
   $default_age                  = { 'min'                  => 2, 'max'       => 0, }

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -54,6 +54,7 @@ describe 'unattended_upgrades' do
             'fix_interrupted_dpkg' => false,
             'remove'               => false,
             'reboot'               => true,
+            'reboot_withusers'     => false,
             'reboot_time'          => '03:00'
           },
           verbose: 1,
@@ -119,6 +120,8 @@ describe 'unattended_upgrades' do
           %r{Unattended-Upgrade::Remove-Unused-Dependencies "false";}
         ).with_content(
           %r{Unattended-Upgrade::Automatic-Reboot "true";}
+        ).with_content(
+          %r{Unattended-Upgrade::Automatic-Reboot-WithUsers "false";}
         ).with_content(
           %r{Unattended-Upgrade::Automatic-Reboot-Time "03:00";}
         ).with_content(

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -104,6 +104,10 @@ Unattended-Upgrade::Remove-Unused-Dependencies "<%= @_auto['remove'].to_s %>";
 // if the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "<%= @_auto['reboot'].to_s %>";
 
+// Automatically reboot even if there are users currently logged in
+// when Unattended-Upgrade::Automatic-Reboot is set to true
+Unattended-Upgrade::Automatic-Reboot-WithUsers "<%= @_auto['reboot_withusers'].to_s %>";
+
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"

--- a/types/auto.pp
+++ b/types/auto.pp
@@ -3,6 +3,7 @@ type Unattended_upgrades::Auto = Struct[
     Optional['clean']                => Variant[Integer[0], Enum['always']],
     Optional['fix_interrupted_dpkg'] => Boolean,
     Optional['reboot']               => Boolean,
+    Optional['reboot_withusers']     => Boolean,
     Optional['reboot_time']          => String,
     Optional['remove']               => Boolean,
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for the "Unattended-Upgrade::Automatic-Reboot-WithUsers" option. Controls whether to proceed with an automatic reboot after unattended-upgrades if users are logged into the system.

#### This Pull Request (PR) fixes the following issues
N/A
