### PR TITLE
Fix default LinuxMint origins so they pass validation

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class unattended_upgrades::params {
       ]
     }
     'LinuxMint': {
-      $origins = ['origin=${distro_id}:${distro_codename}-security',] #lint:ignore:single_quote_string_with_variables
+      $origins = ['origin=${distro_id},suite=${distro_codename}-security',] #lint:ignore:single_quote_string_with_variables
     }
     default: {
       $origins       = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,7 +38,7 @@ class unattended_upgrades::params {
       ]
     }
     'LinuxMint': {
-      $origins = ['${distro_id}:${distro_codename}-security',] #lint:ignore:single_quote_string_with_variables
+      $origins = ['origin=${distro_id}:${distro_codename}-security',] #lint:ignore:single_quote_string_with_variables
     }
     default: {
       $origins       = undef


### PR DESCRIPTION
#### Pull Request (PR) description

The default origins for "LinuxMint" do not pass [validation](https://github.com/voxpupuli/puppet-unattended_upgrades/blob/279c4a8d7bc1bdfd1bc3d0db8448ce0ac387a1eb/types/origin.pp#L2) and cause an error when puppet agent runs:

> Error while evaluating a Function Call, Class[Unattended_upgrades]: parameter 'origins' index 0 expects a match for Unattended_upgrades::Origin = Pattern[/^(origin|codename|label|site|suite|component|archive|[oalcn])=[^,]+(,(origin|codename|label|site|suite|component|archive|[oalcn])=[^,]+)*/], got '${distro_id}:${distro_codename}-security'

This change tweaks the origin line to pass validation, allowing puppet agent runs to succeed.

#### This Pull Request (PR) fixes the following issues
n/a
