### PR TITLE
Add allow_downgrade option to unattended-upgrades.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ altering some of the default settings.
 * `syslog_enable` (`undef`): Enable logging to syslog. Default is False.
 * `syslog_facility` (`undef`): Specify syslog facility. Default is `daemon`.
 * `only_on_ac_power` (`undef`): Download and install upgrades only on AC power. Default is `true`.
+* `allow_downgrade` (`undef`): Allow package downgrade if Pin-Priority exceeds 1000. Default is `false`.
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class unattended_upgrades (
   Optional[String]                          $syslog_facility        = undef,
   Optional[Boolean]                         $only_on_ac_power       = undef,
   Optional[Boolean]                         $whitelist_strict       = undef,
+  Optional[Boolean]                         $allow_downgrade        = undef,
 ) inherits unattended_upgrades::params {
   # apt::conf settings require the apt class to work
   include apt

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -77,6 +77,7 @@ describe 'unattended_upgrades' do
           syslog_facility: 'daemon',
           only_on_ac_power: false,
           whitelist_strict: true,
+          allow_downgrade: false,
         }
       end
 
@@ -144,6 +145,8 @@ describe 'unattended_upgrades' do
           %r{Unattended-Upgrade::SyslogFacility "daemon";}
         ).with_content(
           %r{Unattended-Upgrade::OnlyOnACPower "false";}
+        ).with_content(
+          %r{Unattended-Upgrade::Allow-downgrade "false";}
         )
       end
 

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -134,3 +134,8 @@ Unattended-Upgrade::SyslogFacility "<%= @syslog_facility %>";
 // (i.e. skip or gracefully stop updates on battery)
 Unattended-Upgrade::OnlyOnACPower "<%= @only_on_ac_power %>";
 <%- end -%>
+
+<%- unless @allow_downgrade.nil? -%>
+// Allow package downgrade if Pin-Priority exceeds 1000
+Unattended-Upgrade::Allow-downgrade "<%= @allow_downgrade %>";
+<%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Added support for the "Unattended-Upgrade::Allow-downgrade" option. Controls whether unattended-upgrades should downgrade packets when their pin priority exceeds 1000.

#### This Pull Request (PR) fixes the following issues

N/A