### PR TITLE
Add Debian 12 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class unattended_upgrades::params {
 
   case downcase($facts['os']['name']) {
     'debian', 'raspbian': {
-      if Integer($facts['os']['release']['major']) >= 11 {
+      if versioncmp($facts['os']['release']['major'], '11') >= 0 {
         $origins            = [
           'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
           'origin=Debian,codename=${distro_codename}-security,label=Debian-Security', #lint:ignore:single_quote_string_with_variables

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,19 +12,16 @@ class unattended_upgrades::params {
 
   case downcase($facts['os']['name']) {
     'debian', 'raspbian': {
-      case fact('os.distro.codename') {
-        'bullseye': {
-          $origins            = [
-            'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
-            'origin=Debian,codename=${distro_codename}-security,label=Debian-Security', #lint:ignore:single_quote_string_with_variables
-          ]
-        }
-        default: {
-          $origins            = [
-            'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
-            'origin=Debian,codename=${distro_codename},label=Debian-Security', #lint:ignore:single_quote_string_with_variables
-          ]
-        }
+      if Integer($facts['os']['release']['major']) >= 11 {
+        $origins            = [
+          'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
+          'origin=Debian,codename=${distro_codename}-security,label=Debian-Security', #lint:ignore:single_quote_string_with_variables
+        ]
+      } else {
+        $origins            = [
+          'origin=Debian,codename=${distro_codename},label=Debian', #lint:ignore:single_quote_string_with_variables
+          'origin=Debian,codename=${distro_codename},label=Debian-Security', #lint:ignore:single_quote_string_with_variables
+        ]
       }
     }
     'ubuntu', 'neon': {

--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/spec/classes/other_debians_spec.rb
+++ b/spec/classes/other_debians_spec.rb
@@ -12,7 +12,9 @@ describe 'unattended_upgrades' do
           name: 'Raspbian',
           family: 'Debian',
           release: {
-            full: '8.0'
+            full: '8.0',
+            major: '8',
+            minor: '0'
           }
         },
         osfamily: 'Debian',


### PR DESCRIPTION
Debian 11 (bullseye) changed the codename in the security Release file to specify <codename>-security instead of just <security>.

For bullseye this was already correctly handled, but for later releases this module would fall back to the earlier style.

Fix origins to add -security for all releases >= bullseye and not just for exactly bullseye.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
