### PR TITLE
More specific type for extra_origins

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class unattended_upgrades (
   Boolean                                   $minimal_steps          = true,
   Array[Unattended_upgrades::Origin]        $origins                = $unattended_upgrades::params::origins,
   String[1]                                 $package_ensure         = installed,
-  Array[String[1]]                          $extra_origins          = [],
+  Array[Unattended_upgrades::Origin]        $extra_origins          = [],
   Optional[Integer[0]]                      $random_sleep           = undef,
   Optional[String]                          $sender                 = undef,
   Integer[0]                                $size                   = 0,


### PR DESCRIPTION
In https://github.com/voxpupuli/puppet-unattended_upgrades/pull/204 the `origins` type was marked with this type, but the `extra_origins` type should also be validated in the same way.