### PR TITLE
Support passing dpkg options

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,12 @@ altering some of the default settings.
 * `allow_downgrade` (`undef`): Allow package downgrade if Pin-Priority exceeds 1000. Default is `false`.
 * `dpkg_options` (`[]`): Pass options to `dpkg`
 
- Force dpkg to keep the old configuration files:
-```
-class { 'unattended_upgrades':
-  dpkg_options => ['--force-confold']
-}
-```
+  Force dpkg to keep the old configuration files:
+
+  ```puppet
+  class { 'unattended_upgrades':
+    dpkg_options => ['--force-confold'],
+  }
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ altering some of the default settings.
 * `syslog_facility` (`undef`): Specify syslog facility. Default is `daemon`.
 * `only_on_ac_power` (`undef`): Download and install upgrades only on AC power. Default is `true`.
 * `allow_downgrade` (`undef`): Allow package downgrade if Pin-Priority exceeds 1000. Default is `false`.
+* `dpkg_options` (`[]`): Pass options to `dpkg`
+
+ Force dpkg to keep the old configuration files:
+```
+class { 'unattended_upgrades':
+  dpkg_options => ['--force-confold']
+}
+```
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class unattended_upgrades (
   Optional[Boolean]                         $only_on_ac_power       = undef,
   Optional[Boolean]                         $whitelist_strict       = undef,
   Optional[Boolean]                         $allow_downgrade        = undef,
+  Array[String[1]]                          $dpkg_options           = [],
 ) inherits unattended_upgrades::params {
   # apt::conf settings require the apt class to work
   include apt

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -78,6 +78,7 @@ describe 'unattended_upgrades' do
           only_on_ac_power: false,
           whitelist_strict: true,
           allow_downgrade: false,
+          dpkg_options: ['--force-confold', '--force-confdef'],
         }
       end
 
@@ -147,6 +148,8 @@ describe 'unattended_upgrades' do
           %r{Unattended-Upgrade::OnlyOnACPower "false";}
         ).with_content(
           %r{Unattended-Upgrade::Allow-downgrade "false";}
+        ).with_content(
+          %r{DPkg::Options\s+\{\n\s+"--force-confold";\n\s+"--force-confdef";\n\};}
         )
       end
 

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -139,3 +139,11 @@ Unattended-Upgrade::OnlyOnACPower "<%= @only_on_ac_power %>";
 // Allow package downgrade if Pin-Priority exceeds 1000
 Unattended-Upgrade::Allow-downgrade "<%= @allow_downgrade %>";
 <%- end -%>
+
+<%- unless @dpkg_options.empty? -%>
+DPkg::Options {
+<% @dpkg_options.each do |opt| -%>
+    "<%= opt %>";
+<%- end -%>
+};
+<%- end -%>


### PR DESCRIPTION
Support passing `dpkg::options`, as [mentioned in documentation](https://github.com/mvo5/unattended-upgrades/blob/master/README.md#supported-options-reference).

The setting will be applied globally, there's no way to pass the option to unattended upgrades only :disappointed: 
