### PR TITLE
Add skip_updates_on_metered_connection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ altering some of the default settings.
 * `syslog_enable` (`undef`): Enable logging to syslog. Default is False.
 * `syslog_facility` (`undef`): Specify syslog facility. Default is `daemon`.
 * `only_on_ac_power` (`undef`): Download and install upgrades only on AC power. Default is `true`.
+* `skip_updates_on_metered_connection` (`undef`): Download and install upgrades only on non-metered connection. Default is `true`.
 * `allow_downgrade` (`undef`): Allow package downgrade if Pin-Priority exceeds 1000. Default is `false`.
 * `dpkg_options` (`[]`): Pass options to `dpkg`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class unattended_upgrades (
   Optional[Boolean]                         $syslog_enable          = undef,
   Optional[String]                          $syslog_facility        = undef,
   Optional[Boolean]                         $only_on_ac_power       = undef,
+  Optional[Boolean]                         $skip_updates_on_metered_connection = undef,
   Optional[Boolean]                         $whitelist_strict       = undef,
   Optional[Boolean]                         $allow_downgrade        = undef,
   Array[String[1]]                          $dpkg_options           = [],

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -76,6 +76,7 @@ describe 'unattended_upgrades' do
           syslog_enable: true,
           syslog_facility: 'daemon',
           only_on_ac_power: false,
+          skip_updates_on_metered_connection: false,
           whitelist_strict: true,
           allow_downgrade: false,
           dpkg_options: ['--force-confold', '--force-confdef'],
@@ -146,6 +147,8 @@ describe 'unattended_upgrades' do
           %r{Unattended-Upgrade::SyslogFacility "daemon";}
         ).with_content(
           %r{Unattended-Upgrade::OnlyOnACPower "false";}
+        ).with_content(
+          %r{Unattended-Upgrade::Skip-Updates-On-Metered-Connections "false";}
         ).with_content(
           %r{Unattended-Upgrade::Allow-downgrade "false";}
         ).with_content(

--- a/templates/unattended-upgrades.erb
+++ b/templates/unattended-upgrades.erb
@@ -135,6 +135,12 @@ Unattended-Upgrade::SyslogFacility "<%= @syslog_facility %>";
 Unattended-Upgrade::OnlyOnACPower "<%= @only_on_ac_power %>";
 <%- end -%>
 
+<%- unless @skip_updates_on_metered_connection.nil? -%>
+// Download and install upgrades only on non-metered connection
+// (i.e. skip or gracefully stop updates on a metered connection)
+Unattended-Upgrade::Skip-Updates-On-Metered-Connections "<%= @skip_updates_on_metered_connection %>";
+<%- end -%>
+
 <%- unless @allow_downgrade.nil? -%>
 // Allow package downgrade if Pin-Priority exceeds 1000
 Unattended-Upgrade::Allow-downgrade "<%= @allow_downgrade %>";


### PR DESCRIPTION
#### Pull Request (PR) description
Expose the `Unattended-Upgrade::Skip-Updates-On-Metered-Connections` apt.conf setting, similar to added support for the `Unattended-Upgrade::OnlyOnACPower` in #208.

#### This Pull Request (PR) fixes the following issues
n/a