### PR TITLE
Deprecate random_sleep

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -168,7 +168,7 @@ Default value: `[]`
 
 Data type: `Optional[Integer[0]]`
 
-Maximum random sleep in seconds.
+Maximum random sleep in seconds. This parameter is deprecated and will be removed in a future release.
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@
 # @param extra_origins
 #   Array of extra origins to allow automatic upgrades from.
 # @param random_sleep
-#   Maximum random sleep in seconds.
+#   Maximum random sleep in seconds. This parameter is deprecated and will be removed in a future release.
 # @param sender
 #   Email sender address.
 # @param size
@@ -139,5 +139,10 @@ class unattended_upgrades (
     priority      => 20,
     require       => Package['unattended-upgrades'],
     notify_update => $notify_update,
+  }
+
+  # Emit a warning if the deprecated parameter `random_sleep` is used
+  if $random_sleep != undef {
+    warning('The parameter `random_sleep` is deprecated and will be removed in a future release.')
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Deprecate `random_sleep` via docs and a runtime warning.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-unattended_upgrades/issues/278
